### PR TITLE
Stack of nodes + Enhancements

### DIFF
--- a/babble/src/components.lua
+++ b/babble/src/components.lua
@@ -60,11 +60,24 @@ end
 local Link = Class()
 function Link:init(node, func)
    self.node = node
-   self.func = func
+   local mt = getmetatable(func)
+   if type(func) == 'function' or mt and type(mt.__call) == 'function' then
+      self.func = func
+   elseif type(func) == 'string' then
+      self.link = func
+   --[[
+   else
+      error("bad argument #1 to 'link' (function expected)", 3)
+   ]]
+   end
 end
 
 function Link:update(dt)
-   return self.func() or true
+   if self.link then
+      return self.link
+   else
+      return self.func() or true
+   end
 end
 
 

--- a/babble/src/components.lua
+++ b/babble/src/components.lua
@@ -46,25 +46,26 @@ end
 
 
 local Script = Class()
-function Script:init(node, func, args)
+function Script:init(node, func, ...)
    self.node = node
    self.func = func
-   self.args = args or {}
+   self.args = {..., n = select('#', ...)}
 end
 
 function Script:update(dt)
-   return self.func(self.node, dt, self.args)
+   return self.func(self.node, dt, unpack(self.args, self.args.n))
 end
 
 
 local Link = Class()
-function Link:init(node, func)
+function Link:init(node, func, ...)
    self.node = node
    self.func = func
+   self.args = {..., n = select('#', ...)}
 end
 
 function Link:update(dt)
-   return self.func() or true
+   return self.func(dt, unpack(self.args, 1, self.args.n)) or true
 end
 
 

--- a/babble/src/dialogue.lua
+++ b/babble/src/dialogue.lua
@@ -5,8 +5,9 @@ local Node  = require(Path..".node")
 
 local Dialogue = Class()
 function Dialogue:init()
+   self.finished = false
    self.nodes       = {}
-   self.currentNode = "start"
+   self.stack       = {}
 
    self.buffer = {}
 end
@@ -19,8 +20,51 @@ function Dialogue:startNode(id, custom)
    return node
 end
 
+function Dialogue:switch(id)
+   local node = self.nodes[id]
+
+   if not node then
+      error(("Invalid node id '%s'"):format(id), 2)
+   end
+
+   self.finished = false
+   self.stack = {node:newInstance()}
+
+   return self
+end
+
+function Dialogue:push(id)
+   local node = self.nodes[id]
+
+   if not node then
+      error(("Invalid node id '%s'"):format(id), 2)
+   end
+
+   self.finished = false
+   self.stack[#self.stack + 1] = node:newInstance()
+
+   return self
+end
+
+function Dialogue:pop()
+   self.stack[#self.stack] = nil
+
+   if #self.stack == 0 then
+     self.finished = true
+   end
+
+   return self
+end
+
 function Dialogue:update(dt)
-   self.nodes[self.currentNode]:update(dt)
+   local node = self.stack[#self.stack]
+
+   if node then
+      if node:update(dt) then
+        self:pop()
+        return self.finished
+      end
+   end
 end
 
 function Dialogue:draw(x, y, w, h)

--- a/babble/src/node.lua
+++ b/babble/src/node.lua
@@ -4,6 +4,8 @@ local Class      = require(Path..".class")
 local Components = require(Path..".components")
 
 local Node = Class()
+local NodeInstance = Class()
+
 Node.custom = {
    colors     = {},
    typeSpeeds = {},
@@ -25,11 +27,13 @@ function Node:init(parent, id, custom)
       color     = self.default.color,
       typeSpeed = self.default.typeSpeed,
       typeSound = self.default.typeSound,
-
-      component = 1,
    }
 
    self.components = {}
+end
+
+function Node:newInstance ()
+  return NodeInstance(self)
 end
 
 function Node:setColor(color)
@@ -63,17 +67,23 @@ function Node:endNode()
    return self.parent
 end
 
-function Node:update(dt)
-   local component = self.components[self.current.component]
+function NodeInstance:init(node)
+  self.node = node
+  self.current = 1
+  self.parent = node.parent
+end
+
+function NodeInstance:update(dt)
+   local component = self.node.components[self.current]
 
    if component then
       local state = component:update(dt)
 
       if state then
-         self.current.component = self.current.component + 1
+         self.current = self.current + 1
 
          if type(state) == "string" then
-            self.parent.currentNode = state
+            self.parent:push(state)
          end
       end
    else
@@ -81,7 +91,7 @@ function Node:update(dt)
    end
 end
 
-function Node:draw()
+function NodeInstance:draw()
 end
 
 for name, component in pairs(Components) do

--- a/main.lua
+++ b/main.lua
@@ -11,7 +11,9 @@ local d = Babble.dialogue()
 
       :link(function()
          return preference == "chocolate" and "likes_chocolate" or "likes_strawberry"
-      end, true) -- True so it will link back when done
+      end)
+
+      :print('Eat as much as you want!')
    :endNode()
 
    :startNode("likes_chocolate")
@@ -21,6 +23,8 @@ local d = Babble.dialogue()
    :startNode("likes_strawberry")
       :print("Strawberry is really nice, yeah.")
    :endNode()
+
+   :switch('start')
 
 function love.update(dt)
    d:update(dt)


### PR DESCRIPTION
* `Dialogue` now creates `NodeInstances` when moving to a `Node`.
* `NodeInstances` hold position information and handle updates.
* The `Dialogue` holds a stack of `NodeInstances`, and it can `push`, `pop` or `switch` at any time.

Fixes #1, Fixes #7

* Links support a string as argument, which makes them directly go to the specified node

Fixes #8 

* `Scripts` now take the current `Node`, `dt` and the complete list of arguments (not only an `args` table)
* `Links` now take `dt` and the complete list of arguments