### PR TITLE
Remove pause from components/init.lua

### DIFF
--- a/babble/src/components/init.lua
+++ b/babble/src/components/init.lua
@@ -3,7 +3,6 @@ local Path = (...):gsub('%.init$', '')
 local Components = {}
 
 Components.link   = require(Path..".link")
-Components.pause  = require(Path..".pause")
 Components.print  = require(Path..".print")
 Components.script = require(Path..".script")
 Components.setter = require(Path..".setter")


### PR DESCRIPTION
Fixes issue introduced in d378262b1cba8b1da05f6bae8a94b3b6aae3004c where require failed to load the non-exitent components/pause.lua